### PR TITLE
Remove search indexing hack

### DIFF
--- a/src/circuitcollective/game/CustomGameRepositoryImpl.java
+++ b/src/circuitcollective/game/CustomGameRepositoryImpl.java
@@ -19,11 +19,6 @@ public class CustomGameRepositoryImpl implements CustomGameRepository {
 
     @Override
     public List<Game> search(String query, int limit, int offset, String... fields) {
-        try { // TODO: Temp hack
-            Search.session(entityManager).massIndexer(Game.class).startAndWait();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         return Search.session(entityManager).search(Game.class).where(e -> e.match().fields(fields).matching(query).fuzzy()).fetch(offset, limit).hits();
     }
 }

--- a/src/circuitcollective/game/GameController.java
+++ b/src/circuitcollective/game/GameController.java
@@ -1,7 +1,8 @@
 package circuitcollective.game;
 
-import org.springframework.transaction.annotation.*;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.*;
 
 import java.util.*;
 
@@ -34,16 +35,15 @@ public class GameController {
         @RequestParam(name = "o", required = false, defaultValue = "0") int offset,
         @RequestParam(name = "f", required = false, defaultValue = "name") String... fields // Comma separated list: a,b,c
     ) {
-        if (limit > 25 || limit < 1) throw new IllegalArgumentException("Invalid limit. Must be 1-25");
+        if (limit > 25 || limit < 1) throw new IllegalArgumentException("Invalid limit. Must be 1-25"); // TODO: Replace with ResponseStatusExceptions
         if (offset < 0) throw new IllegalArgumentException("Invalid offset. Cannot be below 0");
         return repo.search(query, limit, offset, fields);
     }
 
     /** Gets a game */
-    @Transactional
     @GetMapping("/{id}")
     Game get(@PathVariable long id) {
-        return repo.findById(id).get();
+        return repo.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Game not found with id " + id));
     }
 
     //endregion

--- a/src/resources/application.properties
+++ b/src/resources/application.properties
@@ -9,3 +9,8 @@ spring.jpa.properties.hibernate.search.backend.directory.root=searchindex
 
 spring.mvc.view.prefix = /WEB-INF/classes/templates
 spring.mvc.view.suffix = .html
+
+#---
+spring.config.activate.on-profile=test
+spring.jpa.properties.hibernate.search.backend.directory.type=local-heap
+spring.jpa.properties.hibernate.search.automatic_indexing.synchronization.strategy = sync

--- a/src/resources/templates/index.html
+++ b/src/resources/templates/index.html
@@ -7,7 +7,7 @@
     <script src="/js/main.js"></script>
 </head>
 <body>
-<div th:replace="fragments/header :: header"></div>
+<div th:replace="~{fragments/header :: header}"></div>
 <link rel="stylesheet" href="/css/database_menu_ui.css">
 
 <div class="top_nav">

--- a/test/circuitcollective/game/GameControllersTest.java
+++ b/test/circuitcollective/game/GameControllersTest.java
@@ -3,7 +3,6 @@ package circuitcollective.game;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.*;
 import jakarta.persistence.*;
-import org.hibernate.search.mapper.orm.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.*;
 import org.mapstruct.factory.*;
@@ -12,9 +11,9 @@ import org.springframework.boot.test.autoconfigure.jdbc.*;
 import org.springframework.boot.test.context.*;
 import org.springframework.data.util.*;
 import org.springframework.http.*;
+import org.springframework.test.context.*;
 import org.springframework.test.web.servlet.*;
 import org.springframework.test.web.servlet.setup.*;
-import org.springframework.transaction.support.*;
 import org.springframework.web.context.*;
 
 import java.util.*;
@@ -31,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureTestDatabase
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @Execution(ExecutionMode.SAME_THREAD)
+@ActiveProfiles("test")
 public class GameControllersTest {
     @Autowired
     private WebApplicationContext context;
@@ -52,9 +52,6 @@ public class GameControllersTest {
         revenue = 160.0;
         price = 80.0;
     }}, g2 = new Game(); // Bad game
-
-    @Autowired
-    TransactionTemplate txTemplate;
 
     @BeforeEach
     public void setup() {
@@ -123,17 +120,6 @@ public class GameControllersTest {
                 throw new RuntimeException(e);
             }
         }
-
-        txTemplate.execute(status -> {
-            try {
-                 Search.session(entityManager).massIndexer(Game.class).startAndWait();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        });
-
-
 
         var apple = search("Apple"); // Should have 1 result
         System.out.println(apple);


### PR DESCRIPTION
Removes the need to index search on startup (we were doing it on every search as i needed a quick fix during the lab which is even worse). The solution is to just store the index in the heap when running unit tests.